### PR TITLE
Fix for microWakeWord multi-device

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -11,7 +11,7 @@ esphome:
   project:
     name: tetele.onju_voice_satellite
     version: '${project_version}'
-  min_version: 2024.2.0
+  min_version: 2024.3.0
   platformio_options:
     board_build.flash_mode: dio
     build_flags: "-DBOARD_HAS_PSRAM"

--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -134,6 +134,7 @@ micro_wake_word:
   on_wake_word_detected:
     then:
       - voice_assistant.start
+          wake_word: !lambda return wake_word;
 
 speaker:
   - platform: i2s_audio


### PR DESCRIPTION
If several devices use both openWakeWord and microWakeWord, calling out the same wake word could make multiple such devices respond.

This was fixed in https://github.com/home-assistant/core/pull/111585 but needs a config update to be up to date with the fix

See also https://github.com/home-assistant/core/issues/113690 for a better description of the issue