### PR TITLE
Update onju-voice.yaml

### DIFF
--- a/esphome/onju-voice.yaml
+++ b/esphome/onju-voice.yaml
@@ -12,6 +12,8 @@ esphome:
     name: tetele.onju_voice_satellite
     version: '${project_version}'
   min_version: 2023.11.6
+  platformio_options:
+    board_build.flash_mode: dio
   on_boot:
     then:
       - light.turn_on:


### PR DESCRIPTION
Hi,

First of all I just want to say a big thanks for the work,

I noticed that I got the same reboot issue loop as in this reported [issue](https://github.com/tetele/onju-voice-satellite/issues/6) in the normal config (not the micro_wake_word).

I am running esphome version 2024.3.1, when I added the following to the config the device worked like a charm so i'm creating a PR for this as I am probably not the only one that will run into the same issue with this version.

`board_build.flash_mode: dio`
