### PR TITLE
Add friendly name to config

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -5,12 +5,13 @@ substitutions:
   device_description: "Onju Voice Satellite with ESPHome software and microWakeWord"
 
 esphome:
-  name: '${name}'
-  comment: '${device_description}'
+  name: "${name}"
+  friendly_name: "{$friendly_name}"
+  comment: "${device_description}"
   name_add_mac_suffix: true
   project:
     name: tetele.onju_voice_satellite
-    version: '${project_version}'
+    version: "${project_version}"
   min_version: 2024.3.0
   platformio_options:
     board_build.flash_mode: dio
@@ -57,8 +58,6 @@ psram:
   mode: octal
   speed: 80MHz
 
-
-
 # Enable logging
 logger:
 
@@ -71,7 +70,7 @@ improv_serial:
 wifi:
   # Set up a wifi access point
   ap:
-    ssid: '${friendly_name}'
+    ssid: "${friendly_name}"
 
 # In combination with the `ap` this allows the user
 # to provision wifi credentials to the device via WiFi AP.

--- a/esphome/onju-voice.yaml
+++ b/esphome/onju-voice.yaml
@@ -5,12 +5,13 @@ substitutions:
   device_description: "Onju Voice Satellite with ESPHome software"
 
 esphome:
-  name: '${name}'
-  comment: '${device_description}'
+  name: "${name}"
+  friendly_name: "{$friendly_name}"
+  comment: "${device_description}"
   name_add_mac_suffix: true
   project:
     name: tetele.onju_voice_satellite
-    version: '${project_version}'
+    version: "${project_version}"
   min_version: 2023.11.6
   platformio_options:
     board_build.flash_mode: dio
@@ -63,7 +64,7 @@ improv_serial:
 wifi:
   # Set up a wifi access point
   ap:
-    ssid: '${friendly_name}'
+    ssid: "${friendly_name}"
 
 # In combination with the `ap` this allows the user
 # to provision wifi credentials to the device via WiFi AP.
@@ -216,7 +217,7 @@ number:
 
 esp32_touch:
   setup_mode: false
-  sleep_duration: 2ms 
+  sleep_duration: 2ms
   measurement_duration: 800us
   low_voltage_reference: 0.8V
   high_voltage_reference: 2.4V


### PR DESCRIPTION
Although defined as a substitution, the `friendly_name` was missing from `esphome`.

[According to this](https://www.esphome.io/components/esphome#esphome-configuration-variables), the implications were concerning components defined with `name: None`

Should fix #18