### PR TITLE
Stop media when enabling WW

### DIFF
--- a/esphome/onju-voice.yaml
+++ b/esphome/onju-voice.yaml
@@ -478,7 +478,8 @@ script:
             - lambda: id(va).set_use_wake_word(true);
             - if:
                 condition:
-                  media_player.is_playing:
+                  not:
+                    media_player.is_idle:
                 then:
                   - media_player.stop:
             - if:


### PR DESCRIPTION
Media player needs to be stopped regardless if it was playing or paused when turning on wake word

Fixes #30