### PR TITLE
bugfix: on_end race condition / Speaker buffer full

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -175,11 +175,7 @@ voice_assistant:
         red: 20%
         green: 100%
         effect: speaking
-  on_end:
-    - delay: 500ms
-    - wait_until:
-        not:
-          speaker.is_playing: onju_out
+  on_tts_stream_end:
     - script.execute: reset_led
     - if:
         condition:


### PR DESCRIPTION
"on_end" appears to be called before "on_tts_stream_end" usually this is fine because the previous yaml would wait for the speaker to stop playing to continue. but if the speaker has not started playing in the 500ms delay, then you get a race and we try to end before we actually start outputting audio

this can cause the system to become unstable, and output "Speaker buffer full, trying again next loop" over and over and over again for a long time.

tested with esphome 2024.04

