### PR TITLE
bugfix: fix typos in esphome friendly_name variable

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -6,7 +6,7 @@ substitutions:
 
 esphome:
   name: "${name}"
-  friendly_name: "{$friendly_name}"
+  friendly_name: "${friendly_name}"
   comment: "${device_description}"
   name_add_mac_suffix: true
   project:

--- a/esphome/onju-voice.yaml
+++ b/esphome/onju-voice.yaml
@@ -6,7 +6,7 @@ substitutions:
 
 esphome:
   name: "${name}"
-  friendly_name: "{$friendly_name}"
+  friendly_name: "${friendly_name}"
   comment: "${device_description}"
   name_add_mac_suffix: true
   project:


### PR DESCRIPTION
moves the dollar-sign outside the curly bracket in both configs.