### PR TITLE
refactor: remove redundant build_flag for PSRAM

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -15,7 +15,6 @@ esphome:
   min_version: 2024.3.0
   platformio_options:
     board_build.flash_mode: dio
-    build_flags: "-DBOARD_HAS_PSRAM"
     board_build.arduino.memory_type: qio_opi
   on_boot:
     then:

--- a/esphome/onju-voice.yaml
+++ b/esphome/onju-voice.yaml
@@ -15,7 +15,6 @@ esphome:
   min_version: 2023.11.6
   platformio_options:
     board_build.flash_mode: dio
-    build_flags: "-DBOARD_HAS_PSRAM"
     board_build.arduino.memory_type: qio_opi
   on_boot:
     then:


### PR DESCRIPTION
Not necessary if the psram component is declared in config - according to [this comment](https://github.com/tetele/onju-voice-satellite/pull/37#discussion_r1569595950).