### PR TITLE
Fix audio on ESPHome 2024.5

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -7,8 +7,8 @@ external_components:
   - source:
       type: git
       url: https://github.com/gnumpi/esphome_audio
-      ref: main
-    components: [ adf_pipeline, i2s_audio ]
+      ref: dev-next
+    components: [adf_pipeline, i2s_audio]
 
 esphome:
   name: "${name}"
@@ -132,13 +132,11 @@ interval:
           id: calibrate_touch
           button: 2
 
-
 i2s_audio:
   - id: i2s_shared
     i2s_lrclk_pin: GPIO13
     i2s_bclk_pin: GPIO18
     access_mode: duplex
-
 
 adf_pipeline:
   - platform: i2s_audio
@@ -150,18 +148,18 @@ adf_pipeline:
     adf_alc: true
     bits_per_sample: 32bit
     fixed_settings: true
+    channel: left
 
   - platform: i2s_audio
     type: audio_in
     id: adf_i2s_in
     i2s_audio_id: i2s_shared
     i2s_din_pin: GPIO17
-    channel: right
+    channel: left
     pdm: false
     sample_rate: 16000
     bits_per_sample: 32bit
     fixed_settings: true
-
 
 microphone:
   - platform: adf_pipeline
@@ -182,7 +180,7 @@ media_player:
       - self
       - resampler
       - adf_i2s_out
-    on_state: 
+    on_state:
       then:
         - lambda: |-
             static float old_volume = -1;


### PR DESCRIPTION
Fix #46 with the updates made on the `dev-next` branch of [`esphome_audio`](https://github.com/gnumpi/esphome_audio) made by @gnumpi and the config changes proposed [here](https://github.com/tetele/onju-voice-satellite/issues/46#issuecomment-2154248036).

Thank you very much for these!