### PR TITLE
added brightness atribute to volume change

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -527,6 +527,7 @@ script:
     then:
       - light.turn_on:
           id: top_led
+          brightness: 60%
           effect: show_volume
       - delay: 1s
       - script.execute: reset_led


### PR DESCRIPTION
added this atribute to handle led switch between listening, or general, and the volume show phase. Example Situation resolvment: Having the listen LED's sequence set to 0% that I don't have light in my bedroom for sleeping, but when chaning the Volume, no volume level is show. This resolved this issue for me.