### PR TITLE
ota-platform change - esphome 2024.6.0 update

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -73,6 +73,7 @@ logger:
 
 # Allow OTA updates
 ota:
+  platform: esphome
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:

--- a/esphome/onju-voice.yaml
+++ b/esphome/onju-voice.yaml
@@ -62,6 +62,7 @@ logger:
 
 # Allow OTA updates
 ota:
+  platform: esphome
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:


### PR DESCRIPTION
The ESPhome 2024.6.0 update did a change in the `ota` platform
https://esphome.io/changelog/2024.6.0.html#ota-platforms

Greetings