### PR TITLE
feat: add optional wifi ap pw

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In a valiant attempt to free a Google Nest Mini (2nd generation) from its privac
 
 The purpose of this [ESPHome](https://www.esphome.io/) config is to be able to use such a modded Nest Mini as a voice satellite in Home Assistant. Here's a small demo:
 
-https://youtu.be/fuX6IYa79gA
+[![Watch the demo](https://i.ytimg.com/vi/fuX6IYa79gA/hqdefault.jpg)](https://www.youtube.com/watch?v=fuX6IYa79gA)
 
 ## License
 

--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -3,6 +3,10 @@ substitutions:
   friendly_name: "Onju Voice Satellite"
   project_version: "1.0.0"
   device_description: "Onju Voice Satellite with ESPHome software and microWakeWord"
+# If you configure an ap pw and forget it you need to open up your device again to flash it.
+# Tip: Therfore you can configure the "Setup code" of your Mini as your ap password.
+  wifi_ap_password: ""
+
 external_components:
   - source:
       type: git
@@ -82,6 +86,7 @@ wifi:
   # Set up a wifi access point
   ap:
     ssid: "${friendly_name}"
+    password: "${wifi_ap_password}"
 
 # In combination with the `ap` this allows the user
 # to provision wifi credentials to the device via WiFi AP.

--- a/esphome/onju-voice.yaml
+++ b/esphome/onju-voice.yaml
@@ -3,6 +3,9 @@ substitutions:
   friendly_name: "Onju Voice Satellite"
   project_version: "1.0.0"
   device_description: "Onju Voice Satellite with ESPHome software"
+# If you configure an ap pw and forget it you need to open up your device again to flash it.
+# Tip: Therfore you can configure the "Setup code" of your Mini as your ap password.
+  wifi_ap_password: ""
 
 esphome:
   name: "${name}"
@@ -71,6 +74,7 @@ wifi:
   # Set up a wifi access point
   ap:
     ssid: "${friendly_name}"
+    password: "${wifi_ap_password}"
 
 # In combination with the `ap` this allows the user
 # to provision wifi credentials to the device via WiFi AP.


### PR DESCRIPTION
I added a wifi ap pw option to the `substitutions`.
The default is your current state of no pw.

I added a warning comment that if the user forget the pw it is required to open up the device again.
Therefore I added the hint to use the `Setup code` you can find at the Minis backside as the ap pw.