### PR TITLE
Update onju-voice-microwakeword.yaml

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -50,6 +50,9 @@ esphome:
           blue: 0%
       - delay: 1s
       - script.execute: reset_led
+      - media_player.volume_set:
+          id: onju_out
+          volume: !lambda "return id(volume_percent);"
 
 dashboard_import:
   package_import_url: github://tetele/onju-voice-satellite/esphome/onju-voice-microwakeword.yaml@main
@@ -119,6 +122,10 @@ globals:
   - id: notification
     type: bool
     restore_value: false
+  - id: volume_percent
+    type: float
+    initial_value: "0.5"
+    restore_value: yes
 
 interval:
   - interval: 1s
@@ -192,6 +199,7 @@ media_player:
               }
             }
             old_volume = new_volume;
+            id(volume_percent) = old_volume;
 
 micro_wake_word:
   model: okay_nabu


### PR DESCRIPTION
I noticed that Nest mini is really loud by default. After restart it sets volume back to 100% which is annoying. I added persistent (between device restarts and firmware updates) volume value to not to scare the family during late night tests.