### PR TITLE
Fix max volume on esphome_audio

### DIFF
--- a/esphome/onju-voice-microwakeword.yaml
+++ b/esphome/onju-voice-microwakeword.yaml
@@ -147,6 +147,7 @@ adf_pipeline:
     i2s_dout_pin: GPIO12
     sample_rate: 16000
     adf_alc: true
+    alc_max: .5
     bits_per_sample: 32bit
     fixed_settings: true
     channel: left


### PR DESCRIPTION
Use `alc_max` parameter added in `esphome_audio` https://github.com/gnumpi/esphome_audio/tree/alc_volume_curve

Fixes #60