### PR TITLE
v2.0 refactor - modular config and VPE components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# :warning: THIS BRANCH IS A WORK IN PROGRESS AND SHOULD NOT BE USED :warning:
+
 # Onju Voice satellite
 
 Ever since voice satellites [were introduced](https://www.home-assistant.io/blog/2023/04/27/year-of-the-voice-chapter-2/#composing-voice-assistants) to [Home Assistant](https://www.home-assistant.io/), people wanted to use good microphones and speakers for this purpose, but not many were really available.

--- a/esphome/modular-onju.yaml
+++ b/esphome/modular-onju.yaml
@@ -1,0 +1,13 @@
+substitutions:
+  name: "onju-voice"
+  friendly_name: "Onju Voice Satellite"
+  project_version: "2.0.0-b0"
+  device_description: "Onju Voice Satellite with ESPHome software and microWakeWord"
+
+packages:
+  onju_base: !include onju-modules/base.yaml
+  onju_ble_improv: !include onju-modules/ble_improv.yaml
+  onju_leds: !include onju-modules/leds.yaml
+  onju_controls: !include onju-modules/controls.yaml
+  # audio_gnumpi: !include onju-modules/audio-gnumpi.yaml
+  # onju_va_mww: !include onju-modules/micro_wake_word.yaml

--- a/esphome/modular-onju.yaml
+++ b/esphome/modular-onju.yaml
@@ -10,4 +10,31 @@ packages:
   onju_leds: !include onju-modules/leds.yaml
   onju_controls: !include onju-modules/controls.yaml
   # audio_gnumpi: !include onju-modules/audio-gnumpi.yaml
+  audio_nabu: !include onju-modules/audio-nabu.yaml
   # onju_va_mww: !include onju-modules/micro_wake_word.yaml
+  va_nabu: !include onju-modules/voice_assistant-nabu.yaml
+
+# TEMP https://discord.com/channels/429907082951524364/1324733194980950106
+esp32:
+  framework:
+    version: 4.4.8
+    platform_version: 5.4.0
+
+binary_sensor:
+  - id: !extend action
+    on_click:
+      then:
+        - logger.log:
+            tag: "action_click"
+            format: "Voice assistant is running: %s"
+            args: ['id(va).is_running() ? "yes" : "no"']
+        - if:
+            condition: media_player.is_playing
+            then:
+              - media_player.stop
+        - if:
+            condition: voice_assistant.is_running
+            then:
+              - voice_assistant.stop:
+            else:
+              - voice_assistant.start:

--- a/esphome/modular-onju.yaml
+++ b/esphome/modular-onju.yaml
@@ -12,7 +12,7 @@ packages:
   # audio_gnumpi: !include onju-modules/audio-gnumpi.yaml
   audio_nabu: !include onju-modules/audio-nabu.yaml
   # onju_va_mww: !include onju-modules/micro_wake_word.yaml
-  va_nabu: !include onju-modules/voice_assistant-nabu.yaml
+  onju_mww_nabu: !include onju-modules/micro_wake_word-nabu.yaml
 
 # TEMP https://discord.com/channels/429907082951524364/1324733194980950106
 esp32:

--- a/esphome/onju-modules/audio-nabu.yaml
+++ b/esphome/onju-modules/audio-nabu.yaml
@@ -79,3 +79,25 @@ switch:
     pin:
       number: GPIO21
       inverted: True
+
+script:
+  - id: play_sound
+    parameters:
+      priority: bool
+      sound_file: "media_player::MediaFile*"
+    then:
+      - lambda: |-
+          if (priority) {
+            id(onju_out)
+              ->make_call()
+              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
+              .set_announcement(true)
+              .perform();
+          }
+          if ( (id(onju_out).state != media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING ) || priority) {
+            id(onju_out)
+              ->make_call()
+              .set_announcement(true)
+              .set_local_media_file(sound_file)
+              .perform();
+          }

--- a/esphome/onju-modules/audio-nabu.yaml
+++ b/esphome/onju-modules/audio-nabu.yaml
@@ -1,0 +1,81 @@
+packages:
+  onju_microphone: !include microphone.yaml
+  onju_media_player: !include media_player.yaml
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/esphome/home-assistant-voice-pe
+      ref: dev
+    components:
+      - media_player
+      - microphone
+      - nabu
+      - nabu_microphone
+i2s_audio:
+  - id: i2s_output
+    i2s_lrclk_pin:
+      number: GPIO13
+      allow_other_uses: true
+    i2s_bclk_pin:
+      number: GPIO18
+      allow_other_uses: true
+
+  - id: i2s_input
+    i2s_lrclk_pin:
+      number: GPIO13
+      allow_other_uses: true
+    i2s_bclk_pin:
+      number: GPIO18
+      allow_other_uses: true
+
+speaker:
+  - platform: i2s_audio
+    sample_rate: 16000
+    i2s_mode: primary
+    i2s_dout_pin: GPIO12
+    bits_per_sample: 32bit
+    i2s_audio_id: i2s_output
+    dac_type: external
+    channel: stereo
+    timeout: never
+    buffer_duration: 100ms
+
+microphone:
+  - id: !remove onju_microphone
+  - platform: nabu_microphone
+    i2s_din_pin: GPIO17
+    adc_type: external
+    pdm: false
+    sample_rate: 16000
+    bits_per_sample: 32bit
+    i2s_mode: primary
+    i2s_audio_id: i2s_input
+    channel_0:
+      id: onju_microphone
+      amplify_shift: 2
+    channel_1:
+      id: comm_mic
+      amplify_shift: 2
+
+media_player:
+  - id: !extend onju_out
+    platform: nabu
+    speaker:
+    sample_rate: 16000
+    volume_increment: 0.05
+    volume_min: 0.4
+    volume_max: 0.85
+    files:
+      - id: wake_word_triggered_sound
+        file: ${wakeup_sound_url}
+
+switch:
+  # TODO
+  - platform: gpio
+    id: dac_mute
+    name: DAC mute
+    restore_mode: ALWAYS_OFF
+    pin:
+      number: GPIO21
+      inverted: True

--- a/esphome/onju-modules/audio-nabu.yaml
+++ b/esphome/onju-modules/audio-nabu.yaml
@@ -55,7 +55,7 @@ microphone:
       id: onju_microphone
       amplify_shift: 2
     channel_1:
-      id: comm_mic
+      id: mww_microphone
       amplify_shift: 2
 
 media_player:

--- a/esphome/onju-modules/base.yaml
+++ b/esphome/onju-modules/base.yaml
@@ -47,9 +47,46 @@ esp32:
     type: esp-idf
     version: recommended
     sdkconfig_options:
-      # need to set a s3 compatible board for the adf-sdk to compile
-      # board specific code is not used though
+      CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"
+      CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
+      CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"
+      CONFIG_ESP32S3_INSTRUCTION_CACHE_32KB: "y"
       CONFIG_ESP32_S3_BOX_BOARD: "y"
+      CONFIG_SPIRAM_ALLOW_STACK_EXTERNAL_MEMORY: "y"
+
+      CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP: "y"
+
+      # Settings based on https://github.com/espressif/esp-adf/issues/297#issuecomment-783811702
+      CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM: "16"
+      CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM: "512"
+      CONFIG_ESP32_WIFI_STATIC_TX_BUFFER: "y"
+      CONFIG_ESP32_WIFI_TX_BUFFER_TYPE: "0"
+      CONFIG_ESP32_WIFI_STATIC_TX_BUFFER_NUM: "8"
+      CONFIG_ESP32_WIFI_CACHE_TX_BUFFER_NUM: "32"
+      CONFIG_ESP32_WIFI_AMPDU_TX_ENABLED: "y"
+      CONFIG_ESP32_WIFI_TX_BA_WIN: "16"
+      CONFIG_ESP32_WIFI_AMPDU_RX_ENABLED: "y"
+      CONFIG_ESP32_WIFI_RX_BA_WIN: "32"
+      CONFIG_LWIP_MAX_ACTIVE_TCP: "16"
+      CONFIG_LWIP_MAX_LISTENING_TCP: "16"
+      CONFIG_TCP_MAXRTX: "12"
+      CONFIG_TCP_SYNMAXRTX: "6"
+      CONFIG_TCP_MSS: "1436"
+      CONFIG_TCP_MSL: "60000"
+      CONFIG_TCP_SND_BUF_DEFAULT: "65535"
+      CONFIG_TCP_WND_DEFAULT: "65535" # Adjusted from linked settings to avoid compilation error
+      CONFIG_TCP_RECVMBOX_SIZE: "512"
+      CONFIG_TCP_QUEUE_OOSEQ: "y"
+      CONFIG_TCP_OVERSIZE_MSS: "y"
+      CONFIG_LWIP_WND_SCALE: "y"
+      CONFIG_TCP_RCV_SCALE: "3"
+      CONFIG_LWIP_TCPIP_RECVMBOX_SIZE: "512"
+
+      CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST: "y"
+      CONFIG_BT_BLE_DYNAMIC_ENV_MEMORY: "y"
+
+      CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC: "y"
+      CONFIG_MBEDTLS_SSL_PROTO_TLS1_3: "y" # TLS1.3 support isn't enabled by default in IDF 5.1.5
 
 psram:
   mode: octal

--- a/esphome/onju-modules/base.yaml
+++ b/esphome/onju-modules/base.yaml
@@ -1,0 +1,225 @@
+substitutions:
+  # Phases of the Voice Assistant
+  # The voice assistant is ready to be triggered by a wake word
+  voice_assist_idle_phase_id: "1"
+  # The voice assistant is waiting for a voice command (after being triggered by the wake word)
+  voice_assist_waiting_for_command_phase_id: "2"
+  # The voice assistant is listening for a voice command
+  voice_assist_listening_for_command_phase_id: "3"
+  # The voice assistant is currently processing the command
+  voice_assist_thinking_phase_id: "4"
+  # The voice assistant is replying to the command
+  voice_assist_replying_phase_id: "5"
+  # The voice assistant is not ready
+  voice_assist_not_ready_phase_id: "10"
+  # The voice assistant encountered an error
+  voice_assist_error_phase_id: "11"
+
+esphome:
+  name: "${name}"
+  friendly_name: "${friendly_name}"
+  comment: "${device_description}"
+  name_add_mac_suffix: true
+  project:
+    name: tetele.onju_voice_satellite
+    version: "${project_version}"
+  min_version: 2024.12.2
+  platformio_options:
+    board_build.flash_mode: dio
+    board_build.arduino.memory_type: qio_opi
+  on_boot:
+    priority: 375
+    then:
+      - script.execute: control_led
+      # If after 10 minutes, the device is still initializing (It did not yet connect to Home Assistant), turn off the init_in_progress variable and run the script to refresh the LED status
+      - delay: 10min
+      - if:
+          condition:
+            lambda: return id(init_in_progress);
+          then:
+            - lambda: id(init_in_progress) = false;
+            - script.execute: control_led
+
+esp32:
+  board: esp32-s3-devkitc-1
+  flash_size: 16MB
+  framework:
+    type: esp-idf
+    version: recommended
+    sdkconfig_options:
+      # need to set a s3 compatible board for the adf-sdk to compile
+      # board specific code is not used though
+      CONFIG_ESP32_S3_BOX_BOARD: "y"
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+# Enable logging
+logger:
+
+# Allow OTA updates
+ota:
+  platform: esphome
+
+# Allow provisioning Wi-Fi via serial
+improv_serial:
+
+wifi:
+  id: wifi_id
+  # Set up a wifi access point
+  ap:
+    ssid: "${friendly_name}"
+  on_connect:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_led
+  on_disconnect:
+    - script.execute: control_led
+
+# In combination with the `ap` this allows the user
+# to provision wifi credentials to the device via WiFi AP.
+captive_portal:
+
+api:
+  # TODO
+  id: api_id
+  on_client_connected:
+    - script.execute: control_led
+  on_client_disconnected:
+    - script.execute: control_led
+
+globals:
+  - id: init_in_progress
+    type: bool
+    restore_value: no
+    initial_value: "true"
+  - id: improv_ble_in_progress
+    type: bool
+    restore_value: no
+    initial_value: "false"
+  - id: voice_assistant_phase
+    type: int
+    restore_value: no
+    initial_value: ${voice_assist_idle_phase_id}
+  - id: volume_touched
+    type: bool
+    restore_value: no
+    initial_value: "false"
+
+script:
+  - id: control_led
+    mode: restart
+    then:
+      - lambda: |
+          // TODO
+          // id(check_if_timers_active).execute();
+          // if (id(is_timer_active)){
+          //   id(fetch_first_active_timer).execute();
+          // }
+          if (id(improv_ble_in_progress)) {
+            ESP_LOGD("control_led", "BLE in progress");
+            id(control_led_improv_ble_state).execute();
+          } else if (id(init_in_progress)) {
+            ESP_LOGD("control_led", "Init in progress");
+            id(control_led_init).execute();
+          } else if (!id(wifi_id).is_connected() || !id(api_id).is_connected()){
+            ESP_LOGD("control_led", "Wifi %sconnected, API %sconnected", (id(wifi_id).is_connected() ? "" : "not "), (id(api_id).is_connected() ? "" : "not "));
+            id(control_led_no_ha_connection_state).execute();
+          } else if (id(action).state) {
+            ESP_LOGD("control_led", "Top touchpad pressed");
+            id(control_led_center_button_touched).execute();
+          } else if (id(volume_touched)) {
+            ESP_LOGD("control_led", "Volume touchpad pressed");
+            id(control_led_volume_touched).execute();
+
+          } else if (id(voice_assistant_phase) == ${voice_assist_waiting_for_command_phase_id}) {
+            ESP_LOGD("control_led", "VA: waiting for command");
+            id(control_led_voice_assistant_waiting_for_command_phase).execute();
+          } else if (id(voice_assistant_phase) == ${voice_assist_listening_for_command_phase_id}) {
+            ESP_LOGD("control_led", "VA: listening for command");
+            id(control_led_voice_assistant_listening_for_command_phase).execute();
+          } else if (id(voice_assistant_phase) == ${voice_assist_thinking_phase_id}) {
+            ESP_LOGD("control_led", "VA: thinking");
+            id(control_led_voice_assistant_thinking_phase).execute();
+          } else if (id(voice_assistant_phase) == ${voice_assist_replying_phase_id}) {
+            ESP_LOGD("control_led", "VA: replying");
+            id(control_led_voice_assistant_replying_phase).execute();
+          } else if (id(voice_assistant_phase) == ${voice_assist_error_phase_id}) {
+            ESP_LOGD("control_led", "VA: error");
+            id(control_led_voice_assistant_error_phase).execute();
+          } else if (id(voice_assistant_phase) == ${voice_assist_not_ready_phase_id}) {
+            ESP_LOGD("control_led", "VA: not ready");
+            id(control_led_voice_assistant_not_ready_phase).execute();
+
+          } else if (id(voice_assistant_phase) == ${voice_assist_idle_phase_id}) {
+            ESP_LOGD("control_led", "VA: idle");
+            id(control_led_voice_assistant_idle_phase).execute();
+
+          } else {
+            ESP_LOGD("control_led", "Device idle");
+            id(control_led_idle).execute();
+          }
+    # /*
+    # } else if (id(timer_ringing).state) {
+    #   id(control_led_timer_ringing).execute();
+
+    # voice stuff
+
+    # } else if (id(is_timer_active)) {
+    #   id(control_led_timer_ticking).execute();
+    # } else if (id(master_mute_switch).state) {
+    #   id(control_led_muted_or_silent).execute();
+    # } else if (id(nabu_media_player).volume == 0.0f || id(nabu_media_player).is_muted()) {
+    #   id(control_led_muted_or_silent).execute();
+    # }
+    # //*/
+
+  - id: control_led_init
+    then: []
+
+  - id: control_led_improv_ble_state
+    then: []
+
+  - id: control_led_no_ha_connection_state
+    then: []
+
+  - id: control_led_center_button_touched
+    then: []
+
+  - id: control_led_volume_touched
+    then:
+      - lambda: |
+          id(volume_touched) = false;
+
+  - id: control_led_voice_assistant_waiting_for_command_phase
+    then: []
+
+  - id: control_led_voice_assistant_listening_for_command_phase
+    then: []
+
+  - id: control_led_voice_assistant_thinking_phase
+    then: []
+
+  - id: control_led_voice_assistant_replying_phase
+    then: []
+
+  - id: control_led_voice_assistant_error_phase
+    then: []
+
+  - id: control_led_voice_assistant_not_ready_phase
+    then: []
+
+  - id: control_led_voice_assistant_idle_phase
+    then: []
+
+  - id: control_led_idle
+    then: []
+
+button:
+  - platform: factory_reset
+    id: factory_reset_button
+    name: "Factory Reset"
+    entity_category: diagnostic
+
+  - platform: restart
+    name: "Restart"

--- a/esphome/onju-modules/base.yaml
+++ b/esphome/onju-modules/base.yaml
@@ -225,8 +225,8 @@ script:
 
   - id: control_led_volume_touched
     then:
-      - lambda: |
-          id(volume_touched) = false;
+      - lambda: id(volume_touched) = false;
+      - script.execute: control_led
 
   - id: control_led_voice_assistant_waiting_for_command_phase
     then: []

--- a/esphome/onju-modules/ble_improv.yaml
+++ b/esphome/onju-modules/ble_improv.yaml
@@ -1,0 +1,18 @@
+esp32_ble:
+  name: onju-voice
+
+esp32_improv:
+  authorizer: action
+  on_start:
+    - lambda: id(improv_ble_in_progress) = true;
+    - script.execute: control_led
+  on_provisioned:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_led
+  on_stop:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_led
+
+wifi:
+  on_disconnect:
+    - ble.enable:

--- a/esphome/onju-modules/controls.yaml
+++ b/esphome/onju-modules/controls.yaml
@@ -70,8 +70,8 @@ binary_sensor:
       max_consecutive_anomalies: 10
 
   - platform: gpio
-    id: mute_switch
+    id: hardware_mute_switch
     pin:
       number: GPIO38
       mode: INPUT_PULLUP
-    name: Disable microphone
+    internal: true

--- a/esphome/onju-modules/controls.yaml
+++ b/esphome/onju-modules/controls.yaml
@@ -1,0 +1,77 @@
+external_components:
+  - source: github://pr#7802 # Self calibration for ESP32 touch controls https://github.com/esphome/esphome/pull/7802
+    components: [esp32_touch]
+    # refresh: 0s
+
+esp32_touch:
+  setup_mode: false
+  sleep_duration: 2ms
+  measurement_duration: 800us
+  low_voltage_reference: 0.8V
+  high_voltage_reference: 2.4V
+
+  filter_mode: IIR_16
+  debounce_count: 2
+  noise_threshold: 0
+  jitter_step: 0
+  smooth_mode: IIR_2
+
+  denoise_grade: BIT8
+  denoise_cap_level: L0
+
+binary_sensor:
+  - platform: esp32_touch
+    id: volume_down
+    pin: GPIO4
+    threshold:
+      mode: dynamic
+      initial_value: 539000
+      lookback_num_values: 10
+      scan_interval: 1s
+      max_deviation: 0.5%
+      max_consecutive_anomalies: 10
+    on_press:
+      then:
+        - light.turn_on: left_led
+        - lambda: |
+            id(volume_touched) = true;
+    on_release:
+      then:
+        - light.turn_off: left_led
+
+  - platform: esp32_touch
+    id: volume_up
+    pin: GPIO2
+    threshold:
+      mode: dynamic
+      initial_value: 580000
+      lookback_num_values: 10
+      scan_interval: 1s
+      max_deviation: 0.5%
+      max_consecutive_anomalies: 10
+    on_press:
+      then:
+        - light.turn_on: right_led
+        - lambda: |
+            id(volume_touched) = true;
+    on_release:
+      then:
+        - light.turn_off: right_led
+
+  - platform: esp32_touch
+    id: action
+    pin: GPIO3
+    threshold:
+      mode: dynamic
+      initial_value: 751000
+      lookback_num_values: 10
+      scan_interval: 1s
+      max_deviation: 0.5%
+      max_consecutive_anomalies: 10
+
+  - platform: gpio
+    id: mute_switch
+    pin:
+      number: GPIO38
+      mode: INPUT_PULLUP
+    name: Disable microphone

--- a/esphome/onju-modules/leds.yaml
+++ b/esphome/onju-modules/leds.yaml
@@ -1,0 +1,220 @@
+light:
+  - platform: esp32_rmt_led_strip
+    id: leds
+    pin: GPIO11
+    chipset: SK6812
+    num_leds: 6
+    rgb_order: GRB
+    rmt_channel: 0
+    default_transition_length: 0s
+    gamma_correct: 2.8
+
+  - platform: partition
+    id: left_led
+    segments:
+      - id: leds
+        from: 0
+        to: 0
+    default_transition_length: 100ms
+
+  - platform: partition
+    id: top_led
+    segments:
+      - id: leds
+        from: 1
+        to: 4
+    default_transition_length: 100ms
+    effects:
+      - pulse:
+          name: pulse
+          transition_length: 250ms
+          update_interval: 250ms
+      - pulse:
+          name: slow_pulse
+          transition_length: 1s
+          update_interval: 2s
+      - addressable_twinkle:
+          name: slow_twinkle
+          twinkle_probability: 1%
+      - addressable_twinkle:
+          name: twinkle
+          twinkle_probability: 7%
+      - addressable_twinkle:
+          name: fast_twinkle
+          twinkle_probability: 45%
+      - addressable_scan:
+          name: processing
+          move_interval: 80ms
+      - addressable_flicker:
+          name: speaking
+          intensity: 35%
+      - addressable_random_twinkle:
+          name: random_twinkle
+          twinkle_probability: 45%
+      - addressable_color_wipe:
+          name: swipe_right
+          colors:
+            - red: 100%
+              green: 100%
+              blue: 100%
+              num_leds: 1
+              gradient: true
+            - red: 0
+              green: 0
+              blue: 0
+              num_leds: 2
+              gradient: true
+            - red: 0
+              green: 0
+              blue: 0
+              num_leds: 3
+              gradient: false
+          add_led_interval: 100ms
+          reverse: false
+      - addressable_color_wipe:
+          name: swipe_right_fast
+          colors:
+            - red: 100%
+              green: 100%
+              blue: 100%
+              num_leds: 1
+              gradient: true
+            - red: 0
+              green: 0
+              blue: 0
+              num_leds: 2
+              gradient: true
+            - red: 0
+              green: 0
+              blue: 0
+              num_leds: 3
+              gradient: false
+          add_led_interval: 50ms
+          reverse: false
+      - addressable_color_wipe:
+          name: swipe_left
+          colors:
+            - red: 100%
+              green: 100%
+              blue: 100%
+              num_leds: 1
+              gradient: true
+            - red: 0
+              green: 0
+              blue: 0
+              num_leds: 2
+              gradient: true
+            - red: 0
+              green: 0
+              blue: 0
+              num_leds: 3
+              gradient: false
+          add_led_interval: 100ms
+          reverse: true
+
+  - platform: partition
+    id: right_led
+    segments:
+      - id: leds
+        from: 5
+        to: 5
+    default_transition_length: 100ms
+
+script:
+  - id: !extend control_led_init
+    then:
+      - if:
+          condition:
+            wifi.connected:
+          then:
+            - light.turn_on:
+                id: top_led
+                brightness: 66%
+                red: 9.4%
+                green: 73.3%
+                blue: 94.9%
+                effect: twinkle
+          else:
+            - light.turn_on:
+                id: top_led
+                brightness: 66%
+                red: 100%
+                green: 89%
+                blue: 71%
+                effect: twinkle
+
+  - id: !extend control_led_improv_ble_state
+    then:
+      - light.turn_on:
+          brightness: 66%
+          red: 100%
+          green: 89%
+          blue: 71%
+          id: top_led
+          effect: random_twinkle
+
+  - id: !extend control_led_no_ha_connection_state
+    then:
+      - light.turn_on:
+          brightness: 66%
+          red: 1
+          green: 0
+          blue: 0
+          id: top_led
+          effect: twinkle
+
+  - id: !extend control_led_voice_assistant_idle_phase
+    then:
+      - light.turn_off: top_led
+
+  - id: !extend control_led_voice_assistant_waiting_for_command_phase
+    then:
+      - light.turn_on:
+          brightness: 66%
+          id: top_led
+          effect: swipe_right
+
+  - id: !extend control_led_voice_assistant_listening_for_command_phase
+    then:
+      - light.turn_on:
+          brightness: 66%
+          id: top_led
+          effect: swipe_right_fast
+
+  - id: !extend control_led_voice_assistant_thinking_phase
+    then:
+      - light.turn_on:
+          brightness: 66%
+          id: top_led
+          effect: pulse
+
+  - id: !extend control_led_voice_assistant_replying_phase
+    then:
+      - light.turn_on:
+          brightness: 66%
+          id: top_led
+          effect: swipe_left
+
+  - id: !extend control_led_voice_assistant_error_phase
+    then:
+      - light.turn_on:
+          brightness: 33%
+          red: 1
+          green: 0
+          blue: 0
+          id: top_led
+          effect: pulse
+
+  - id: !extend control_led_voice_assistant_not_ready_phase
+    then:
+      - light.turn_on:
+          brightness: 33%
+          red: 1
+          green: 0
+          blue: 0
+          id: top_led
+          effect: fast_twinkle
+
+  - id: !extend control_led_idle
+    then:
+      - light.turn_off: top_led

--- a/esphome/onju-modules/media_player.yaml
+++ b/esphome/onju-modules/media_player.yaml
@@ -1,0 +1,109 @@
+substitutions:
+  wakeup_sound_url: "https://github.com/tetele/onju-voice-satellite/raw/main/res/wakeup.mp3" # New Notification #7 by UNIVERSFIELD https://freesound.org/people/UNIVERSFIELD/sounds/736267/
+  error_sound_url: "https://github.com/tetele/onju-voice-satellite/raw/main/res/error.mp3" # Error #8 by UNIVERSFIELD https://freesound.org/people/UNIVERSFIELD/sounds/734442/
+  timer_finished_sound_url: "https://github.com/tetele/onju-voice-satellite/raw/main/res/timer_finished.mp3" # New Notification #6 by UNIVERSFIELD https://freesound.org/people/UNIVERSFIELD/sounds/734445/
+
+media_player:
+  - id: onju_out
+    name: None
+    on_state:
+      then:
+        - lambda: |-
+            static float old_volume = -1;
+            float new_volume = id(onju_out).volume;
+            if(abs(new_volume-old_volume) > 0.0001) {
+              if(old_volume != -1) {
+                id(show_volume) = true;
+                id(control_led)->execute();
+              }
+            }
+            old_volume = new_volume;
+
+globals:
+  - id: show_volume
+    type: bool
+    restore_value: no
+    initial_value: "false"
+
+light:
+  - id: !extend top_led
+    effects:
+      - addressable_lambda:
+          name: show_volume
+          update_interval: 50ms
+          lambda: |-
+            int int_volume = int(id(onju_out).volume * 100.0f * it.size());
+            int full_leds = int_volume / 100;
+            int last_brightness = int_volume % 100;
+            int i = 0;
+            for(; i < full_leds; i++) {
+              it[i] = Color::WHITE;
+            }
+            if(i < 4) {
+              it[i++] = Color(64, 64, 64).fade_to_white(last_brightness*256/100);
+            }
+            for(; i < it.size(); i++) {
+              it[i] = Color(64, 64, 64);
+            }
+
+script:
+  - id: set_volume
+    mode: restart
+    parameters:
+      volume: float
+    then:
+      - media_player.volume_set:
+          id: onju_out
+          volume: !lambda return clamp(id(onju_out).volume+volume, 0.0f, 1.0f);
+      - lambda: |
+          id(show_volume) = true;
+      - script.execute: control_led
+
+  - id: !extend control_led_volume_touched
+    then:
+      - if:
+          condition:
+            lambda: "return id(show_volume);"
+          then:
+            - light.turn_on:
+                id: top_led
+                effect: show_volume
+            - delay: 1s
+            - lambda: |
+                id(show_volume) = false;
+            - script.execute: control_led
+          else:
+            - light.turn_off: top_led
+
+binary_sensor:
+  - id: !extend volume_down
+    on_press:
+      then:
+        - script.execute:
+            id: set_volume
+            volume: -0.05
+        - delay: 750ms
+        - while:
+            condition:
+              binary_sensor.is_on: volume_down
+            then:
+              - script.execute:
+                  id: set_volume
+                  volume: -0.05
+              - delay: 150ms
+
+  - id: !extend volume_up
+    on_press:
+      then:
+        - script.execute:
+            id: set_volume
+            volume: 0.05
+        - delay: 750ms
+        - while:
+            condition:
+              binary_sensor.is_on: volume_up
+            then:
+              - script.execute:
+                  id: set_volume
+                  volume: 0.05
+              - delay: 150ms

--- a/esphome/onju-modules/media_player.yaml
+++ b/esphome/onju-modules/media_player.yaml
@@ -13,17 +13,13 @@ media_player:
             float new_volume = id(onju_out).volume;
             if(abs(new_volume-old_volume) > 0.0001) {
               if(old_volume != -1) {
-                id(show_volume) = true;
+                id(volume_touched) = true;
                 id(control_led)->execute();
               }
             }
             old_volume = new_volume;
 
 globals:
-  - id: show_volume
-    type: bool
-    restore_value: no
-    initial_value: "false"
 
 light:
   - id: !extend top_led
@@ -56,24 +52,25 @@ script:
           id: onju_out
           volume: !lambda return clamp(id(onju_out).volume+volume, 0.0f, 1.0f);
       - lambda: |
-          id(show_volume) = true;
+          // Required for when volume is changed externally
+          id(volume_touched) = true;
       - script.execute: control_led
 
-  - id: !extend control_led_volume_touched
+  - id: !remove control_led_volume_touched
+  - id: control_led_volume_touched
+    mode: restart
     then:
       - if:
           condition:
-            lambda: "return id(show_volume);"
+            lambda: "return id(volume_touched);"
           then:
             - light.turn_on:
                 id: top_led
                 effect: show_volume
             - delay: 1s
             - lambda: |
-                id(show_volume) = false;
+                id(volume_touched) = false;
             - script.execute: control_led
-          else:
-            - light.turn_off: top_led
 
 binary_sensor:
   - id: !extend volume_down

--- a/esphome/onju-modules/micro_wake_word-nabu.yaml
+++ b/esphome/onju-modules/micro_wake_word-nabu.yaml
@@ -1,0 +1,77 @@
+packages:
+  onju_voice_assistant: !include voice_assistant-nabu.yaml
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/esphome/home-assistant-voice-pe
+      ref: dev
+    components:
+      - micro_wake_word
+
+micro_wake_word:
+  id: mww
+  models:
+    - model: https://github.com/kahrendt/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
+      id: okay_nabu
+    - model: hey_jarvis
+      id: hey_jarvis
+    - model: hey_mycroft
+      id: hey_mycroft
+    - model: https://github.com/kahrendt/microWakeWord/releases/download/stop/stop.json
+      id: stop
+      internal: true
+  vad:
+  microphone: mww_microphone
+  on_wake_word_detected:
+    # If the wake word is detected when the device is muted (Possible with the software mute switch): Do nothing
+    - if:
+        condition:
+          switch.is_off: mute_switch
+        then:
+          - if:
+              condition:
+                lambda: return id(onju_out)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+              then:
+                lambda: |-
+                  id(onju_out)
+                    ->make_call()
+                    .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
+                    .set_announcement(true)
+                    .perform();
+              else:
+                - if:
+                    condition:
+                      switch.is_on: wake_sound
+                    then:
+                      - script.execute:
+                          id: play_sound
+                          priority: true
+                          sound_file: !lambda return id(wake_word_triggered_sound);
+                      - delay: 300ms
+                - voice_assistant.start:
+                    wake_word: !lambda return wake_word;
+
+voice_assistant:
+  micro_wake_word: mww
+  on_client_connected:
+    - script.execute: turn_on_wake_word
+
+# TODO
+script:
+  - id: !extend turn_on_wake_word
+    then:
+      - micro_wake_word.start
+
+  - id: !extend turn_off_wake_word
+    then:
+      - micro_wake_word.stop
+
+switch:
+  - platform: template
+    id: wake_sound
+    name: Wake sound
+    icon: "mdi:bullhorn"
+    entity_category: config
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON

--- a/esphome/onju-modules/microphone.yaml
+++ b/esphome/onju-modules/microphone.yaml
@@ -1,0 +1,2 @@
+microphone:
+  - id: onju_microphone

--- a/esphome/onju-modules/voice_assistant-nabu.yaml
+++ b/esphome/onju-modules/voice_assistant-nabu.yaml
@@ -17,7 +17,11 @@ voice_assistant:
   noise_suppression_level: 0
   auto_gain: 0 dbfs
   volume_multiplier: 1
+  on_start:
+    - nabu.set_ducking:
+        decibel_reduction: 20 # Number of dB quieter; higher implies more quiet, 0 implies full volume
+        duration: 0.0s # The duration of the transition (default is 0)
   on_end:
-    then:
-      - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
-      - script.execute: control_led
+    - nabu.set_ducking:
+        decibel_reduction: 0 # 0 dB means no reduction
+        duration: 1.0s

--- a/esphome/onju-modules/voice_assistant-nabu.yaml
+++ b/esphome/onju-modules/voice_assistant-nabu.yaml
@@ -1,0 +1,23 @@
+packages:
+  onju_voice_assistant: !include voice_assistant.yaml
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/tetele/home-assistant-voice-pe
+      ref: fix-mww-guarding
+    components:
+      - voice_assistant
+    # refresh: 0s
+
+voice_assistant:
+  microphone: onju_microphone
+  media_player: onju_out
+  use_wake_word: false
+  noise_suppression_level: 0
+  auto_gain: 0 dbfs
+  volume_multiplier: 1
+  on_end:
+    then:
+      - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
+      - script.execute: control_led

--- a/esphome/onju-modules/voice_assistant.yaml
+++ b/esphome/onju-modules/voice_assistant.yaml
@@ -52,11 +52,41 @@ script:
   - id: turn_off_wake_word
     then: []
 
-
-# TODO
 binary_sensor:
-  - id: !extend mute_switch
+  - id: !extend hardware_mute_switch
     on_press:
-      - script.execute: turn_off_wake_word
+      - switch.template.publish:
+          id: mute_switch
+          state: ON
     on_release:
-      - script.execute: turn_on_wake_word
+      - switch.template.publish:
+          id: mute_switch
+          state: OFF
+
+switch:
+  - id: mute_switch
+    platform: template
+    name: Mute
+    restore_mode: RESTORE_DEFAULT_OFF
+    icon: "mdi:microphone-off"
+    entity_category: config
+    turn_on_action:
+      - if:
+          condition:
+            binary_sensor.is_off: hardware_mute_switch
+          then:
+            - switch.template.publish:
+                id: mute_switch
+                state: ON
+    turn_off_action:
+      - if:
+          condition:
+            binary_sensor.is_off: hardware_mute_switch
+          then:
+            - switch.template.publish:
+                id: mute_switch
+                state: OFF
+    on_turn_on:
+      - script.execute: control_led
+    on_turn_off:
+      - script.execute: control_led

--- a/esphome/onju-modules/voice_assistant.yaml
+++ b/esphome/onju-modules/voice_assistant.yaml
@@ -28,6 +28,19 @@ voice_assistant:
   on_tts_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: control_led
+  on_end:
+    - wait_until:
+        not:
+          voice_assistant.is_running:
+    # If the end happened because of an error, let the error phase on for a second
+    - if:
+        condition:
+          lambda: return id(voice_assistant_phase) == ${voice_assist_error_phase_id};
+        then:
+          - delay: 1s
+    # Reset the voice assistant phase id and reset the LED animations.
+    - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
+    - script.execute: control_led
   on_client_connected:
     - lambda: id(init_in_progress) = false;
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};

--- a/esphome/onju-modules/voice_assistant.yaml
+++ b/esphome/onju-modules/voice_assistant.yaml
@@ -1,0 +1,62 @@
+globals:
+  - id: !extend voice_assistant_phase
+    initial_value: ${voice_assist_not_ready_phase_id} # used to make the leds not blink when the va component is not loaded
+
+api:
+  services:
+    - service: start_va
+      then:
+        - voice_assistant.start
+    - service: stop_va
+      then:
+        - voice_assistant.stop
+
+voice_assistant:
+  id: va
+  microphone: onju_microphone
+  use_wake_word: false
+  # TODO
+  on_listening:
+    - lambda: id(voice_assistant_phase) = ${voice_assist_waiting_for_command_phase_id};
+    - script.execute: control_led
+  on_stt_vad_start:
+    - lambda: id(voice_assistant_phase) = ${voice_assist_listening_for_command_phase_id};
+    - script.execute: control_led
+  on_stt_vad_end:
+    - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
+    - script.execute: control_led
+  on_tts_start:
+    - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
+    - script.execute: control_led
+  on_client_connected:
+    - lambda: id(init_in_progress) = false;
+    - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
+    - script.execute: control_led
+  on_client_disconnected:
+    - voice_assistant.stop:
+    - lambda: id(voice_assistant_phase) = ${voice_assist_not_ready_phase_id};
+    - script.execute: control_led
+  on_error:
+    - if:
+        condition:
+          and:
+            - lambda: return !id(init_in_progress);
+            - lambda: return code != "duplicate_wake_up_detected";
+        then:
+          - lambda: id(voice_assistant_phase) = ${voice_assist_error_phase_id};
+          - script.execute: control_led
+
+script:
+  - id: turn_on_wake_word
+    then: []
+  - id: turn_off_wake_word
+    then: []
+
+
+# TODO
+binary_sensor:
+  - id: !extend mute_switch
+    on_press:
+      - script.execute: turn_off_wake_word
+    on_release:
+      - script.execute: turn_on_wake_word


### PR DESCRIPTION
Total refactoring of the config with the following updates:
- usage of [VPE](https://www.home-assistant.io/voice-pe/) [components](https://github.com/esphome/home-assistant-voice-pe/tree/dev/esphome/components)
- split config into smaller, reusable modules (in order to serve multiple similar configs, as per [this idea](https://github.com/tetele/onju-voice-satellite/discussions/100#discussioncomment-11567776))
- extraction of the touchpad self-regulating functionality from the config [to ESPHome](https://github.com/esphome/esphome/pull/7802), thus saving a lot of config lines

Modular config component architecture (components can be used overlappingly, **in this order**):
- `base.yaml` - the core of the config + LED control placeholder scripts which do nothing
- `ble_improv.yaml` - implements [improv](https://www.improv-wifi.com/) over BLE
- `leds.yaml` - defines the LEDs on the unit and allows external light control
- `controls.yaml` - defines touchpads and buttons. Some LED control implemented based on touches
- `microphone.yaml` - defines a microphone placeholder
- `media_player.yaml` - defines a media player placeholder and some volume control +display automations
- `audio-nabu.yaml` - implements audio devices using the VPE components, overrides `microphone` and `media_player`
- `voice_assistant-nabu.yaml` - implements the `voice_assistant` component using audio devices defined in `audio-nabu.yaml`
- `micro_wake_word.yaml-nabu` - implements `micro_wake_word` component